### PR TITLE
Check record type also

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -37,7 +37,7 @@ action :create do
   end
 
   record = zone.records.all.select do |record|
-    record.name == name
+    record.name == name && record.type == type
   end.first
 
   if record.nil?


### PR DESCRIPTION
This adds a little more confidence in selecting the intended record.

It also adds the ability to manage multiple record types with the same name (for example: having an "A" record plus an "MX" record for mysite.com).
