### PR TITLE
replacing scan through DNS with just fetching the desired record.

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -36,9 +36,7 @@ action :create do
     end
   end
 
-  record = zone.records.all.select do |record|
-    record.name == name && record.type == type
-  end.first
+  record = zone.records.get(name, type)
 
   if record.nil?
     create


### PR DESCRIPTION
The call to fog's zone.records.all only returns the first 98 records (sorted alphabetically) so fails if you're trying to change the record for a host named later in the alphabet.  Instead of replacing it with zone.records.all! (which does return all records), I replaced it with a call to fetch the actual record we're interested in, skipping the scan.
