### PR TITLE
Add overwrite parameter

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -18,6 +18,10 @@ action :create do
     @ttl ||= new_resource.ttl
   end
 
+  def overwrite
+    @overwrite ||= new_resource.overwrite
+  end
+
   def zone
     @zone ||= Fog::DNS.new({ :provider => "aws",
                              :aws_access_key_id => new_resource.aws_access_key_id,
@@ -42,8 +46,15 @@ action :create do
     create
     Chef::Log.info "Record created: #{name}"
   elsif value != record.value.first
-    record.destroy
-    create
-    Chef::Log.info "Record modified: #{name}"
+    unless overwrite == false
+      record.destroy
+      create
+      Chef::Log.info "Record modified: #{name}"
+    else
+      Chef::Log.info "Record #{name} should have been modified, but overwrite is set to false."
+      Chef::Log.debug "Current value: #{record.value.first}"
+      Chef::Log.debug "Desired value: #{value}"
+    end
   end
+
 end

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,3 +7,4 @@ attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :zone_id,               :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String
 attribute :aws_secret_access_key, :kind_of => String
+attribute :overwrite,             :kind_of => [ TrueClass, FalseClass ], :default => true


### PR DESCRIPTION
Sometimes I don't want my chef runs to overwrite the value of an existing record. This PR adds an 'overwrite' parameter (defaults to true) which, when false, will cause the provider to not take any action when the record value does not match.
