### PR TITLE
Add missing "name" attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "route53"
 maintainer       "Heavy Water Software Inc."
 maintainer_email "darrin@heavywater.ca"
 license          "Apache 2.0"


### PR DESCRIPTION
While Chef works without this, it is a requirement for tools like Berkshelf
