### PR TITLE
Move xml installation to the xml cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,5 @@ license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.3.0"
+
+depends "xml"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,16 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-xml = package "libxml2-dev" do
-  action :nothing
-end
-xml.run_action( :install )
-
-xslt = package "libxslt1-dev" do
-  action :nothing
-end
-xslt.run_action( :install )
+include_recipe "xml::ruby"
 
 fog = gem_package "fog" do
   action :nothing


### PR DESCRIPTION
Instead of trying to get the xml installation correct for all possible platforms, this introduces a dependency on the xml cookbook (which I think several other popular cookbooks already depend on).
