### PR TITLE
build-essential is required on a fresh machine installation and we need ...

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.3.1"
+
+depends 'apt', '2.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,27 +16,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe 'apt'
 
 if node['platform_family'] == 'debian'
-   xml = package "libxml2-dev" do
+  %w{build-essential libxslt-dev libxml2-dev}.each do |pkg|
+    p = package pkg do
       action :nothing
-   end
-   xml.run_action( :install )
+    end
+    p.run_action(:install) 
+  end
 
-   xslt = package "libxslt1-dev" do
-      action :nothing
-   end
-   xslt.run_action( :install )
 elsif node['platform_family'] == 'rhel'
-   xml = package "libxml2-devel" do
+  %w{libxml2-devel libxslt-devel}.each do |pkg| 
+    p = package pkg do
       action :nothing
-   end
-   xml.run_action( :install )
-
-   xslt = package "libxslt-devel" do
-      action :nothing
-   end
-   xslt.run_action( :install )
+    end
+    p.run_action(:install) 
+  end
 end
 
 chef_gem "fog" do


### PR DESCRIPTION
build-essential is required on a fresh machine installation and we needed to include apt so apt-get update is run before installation
