### PR TITLE
Add version when installing fog chef_gem

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['build_essential']['compiletime'] = true
+default[:route53][:fog_version] = '1.20'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,6 +43,7 @@ end
 
 chef_gem "fog" do
   action :install
+  version node['route53']['fog_version']
 end
 
 require 'rubygems'


### PR DESCRIPTION
Add version attribute when installing `fog` chef_gem to be able to pin it up
