### PR TITLE
add build-essential as dependency and use for building fog gem

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['build_essential']['compiletime'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.3.2"
+
+depends 'build-essential'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'build-essential'
+
 if node['platform_family'] == 'debian'
    xml = package "libxml2-dev" do
       action :nothing


### PR DESCRIPTION
include build essentials, put things in their correct places.
