### PR TITLE
check ttls when determining if records are the same

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -93,7 +93,8 @@ action :create do
 
   def same_record?(record)
     name.eql?(record.name) &&
-      same_value?(record)
+      same_value?(record) &&
+        ttl.eql?(record.ttl.to_i)
   end
 
   def same_value?(record)


### PR DESCRIPTION
I'm migrating a hand-managed zone to one that is partially chef controlled and I noticed the TTLs weren't being updated for existing records.
