### PR TITLE
Fixed fog require error

### DIFF
--- a/providers/record.rb
+++ b/providers/record.rb
@@ -79,7 +79,7 @@ def record_value_or_alias_attributes
 end
 
 action :create do
-  require 'fog/aws/dns'
+  require 'fog'
   require 'nokogiri'
 
   def create
@@ -129,7 +129,7 @@ action :create do
 end
 
 action :delete do
-  require 'fog/aws/dns'
+  require 'fog'
   require 'nokogiri'
 
   if mock?


### PR DESCRIPTION
Hi @slyness 

Running into this issue with latest Fog `v1.24.0`

```
[5] pry(main)> con = Fog::DNS.new(aws)
NameError: uninitialized constant Fog::Parsers::Base
from /Users/arnauddelabarre/.rvm/gems/ruby-1.9.3-p545@chef/gems/fog-1.24.0/lib/fog/aws/parsers/dns/health_check.rb:5:in `<module:AWS>'
```

We should require `fog` directly to get around future refactors of the gem.

Thanks!
