### PR TITLE
Search for zone by name, not id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ route53_record "create a record" do
   value "16.8.4.2"
   type  "A"
   zone_id               node[:route53][:zone_id]
+  zone_name             node[:route53][:zone_name]
   aws_access_key_id     node[:route53][:aws_access_key_id]
   aws_secret_access_key node[:route53][:aws_secret_access_key]
   overwrite true

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,6 +7,7 @@ attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :zone_id,               :kind_of => String
+attribute :zone_name,             :kind_of => String
 attribute :aws_access_key_id,     :kind_of => String
 attribute :aws_secret_access_key, :kind_of => String
 attribute :aws_session_token,     :kind_of => String


### PR DESCRIPTION
I create an internal DNS zone at the same time that I launch instances that update it.  Therefore, I can't hard-code a DNS zone ID into a data bag or environment manifest and expect this cookbook to work.