### PR TITLE
added on_failure option to define behavior when the record change fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the route53 cookbook.
 
+## 1.1.0 (2016-09-21)
+- Fix current_resource_record_set and add alias_target data
+- Remove chef 11 compat in chef_gem resource
+
 ## 1.0.0 (2016-09-16)
 
 - Require Chef 12.1+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ route53_record "create a record" do
   aws_access_key_id     node[:route53][:aws_access_key_id]
   aws_secret_access_key node[:route53][:aws_secret_access_key]
   overwrite true
+  on_failure "warn" (optional - what to do on failure to create. must be either "warn" or "fail")
   action :create
 end
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ version          '1.1.1'
 source_url       'https://github.com/chef-cookbooks/route53'
 issues_url       'https://github.com/chef-cookbooks/route53/issues'
 
-chef_version '>= 12.1'
+#chef_version '>= 12.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures route53'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.1.0'
 source_url       'https://github.com/chef-cookbooks/route53'
 issues_url       'https://github.com/chef-cookbooks/route53/issues'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures route53'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 source_url       'https://github.com/chef-cookbooks/route53'
 issues_url       'https://github.com/chef-cookbooks/route53/issues'
 

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -165,9 +165,7 @@ def change_record(action)
 rescue Aws::Route53::Errors::ServiceError => e
   Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
   Chef::Log.error e.message
-  if on_failure == "fail"
-    raise e
-  end
+  raise e if on_failure == 'fail'
 end
 
 use_inline_resources

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -75,6 +75,10 @@ def zone_id
   @zone_id ||= new_resource.zone_id
 end
 
+def on_failure
+  @on_failure ||= new_resource.on_failure
+end
+
 def route53
   @route53 ||= begin
     if mock?
@@ -161,7 +165,9 @@ def change_record(action)
 rescue Aws::Route53::Errors::ServiceError => e
   Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
   Chef::Log.error e.message
-  # raise 'Route53 Service Error' # TODO
+  if on_failure == "fail"
+    raise e
+  end
 end
 
 use_inline_resources

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -5,7 +5,7 @@ rescue LoadError
   Chef::Log.debug('Did not find aws-sdk installed. Installing now')
 
   chef_gem 'aws-sdk' do
-    compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
+    compile_time true
     action :install
   end
 

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -19,3 +19,4 @@ attribute :aws_region,                  kind_of: String, default: 'us-east-1'
 attribute :overwrite,                   kind_of: [TrueClass, FalseClass], default: true
 attribute :alias_target,                kind_of: Hash
 attribute :mock,                        kind_of: [TrueClass, FalseClass], default: false
+attribute :on_failure,                  kind_of: String, default: 'warn'


### PR DESCRIPTION
This pull adds an on_failure option to the route53_record resource to allow the user to specify if they want the resource to "warn" or "fail" in the event that a record modification is not successful. 
