### PR TITLE
Adds fail_on_error option to the resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ route53_record "create a record" do
   aws_access_key_id     node[:route53][:aws_access_key_id]
   aws_secret_access_key node[:route53][:aws_secret_access_key]
   overwrite true
+  fail_on_error false (set to true to report failure to Chef)
   action :create
 end
 ```

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -163,12 +163,9 @@ def change_record(action)
   response = route53.change_resource_record_sets(request)
   Chef::Log.debug "Changed record - #{action}: #{response.inspect}"
 rescue Aws::Route53::Errors::ServiceError => e
-  if fail_or_error
-    raise
-  else
-    Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
-    Chef::Log.error e.message
-  end
+  raise if fail_or_error
+  Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
+  Chef::Log.error e.message
 end
 
 use_inline_resources

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -75,6 +75,10 @@ def zone_id
   @zone_id ||= new_resource.zone_id
 end
 
+def fail_on_error
+  @fail_on_error ||= new_resource.fail_on_error
+end
+
 def route53
   @route53 ||= begin
     if mock?
@@ -159,9 +163,12 @@ def change_record(action)
   response = route53.change_resource_record_sets(request)
   Chef::Log.debug "Changed record - #{action}: #{response.inspect}"
 rescue Aws::Route53::Errors::ServiceError => e
-  Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
-  Chef::Log.error e.message
-  # raise 'Route53 Service Error' # TODO
+  if fail_or_error
+    raise
+  else
+    Chef::Log.error "Error with #{action}request: #{request.inspect} ::: "
+    Chef::Log.error e.message
+  end
 end
 
 use_inline_resources

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -19,3 +19,4 @@ attribute :aws_region,                  kind_of: String, default: 'us-east-1'
 attribute :overwrite,                   kind_of: [TrueClass, FalseClass], default: true
 attribute :alias_target,                kind_of: Hash
 attribute :mock,                        kind_of: [TrueClass, FalseClass], default: false
+attribute :fail_on_error,               kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
Signed-off-by: Vlad Losev <vlad@vsco.co>

This change adds a `fail_on_error` attribute which allows the resource to propagate errors reported by Route53.

For a little background, we are using Kubernetes, which requires a node to be registered in the DNS. Nodes are brought up in AWS using an autoscaling group. Sometimes multiple nodes come up simultaneously, and every so often they try to register themselves in Route53 so close to each other that Route53 throttles them. Without failure notifications, provisioning proceeds but k8s agents do not start properly. With this PR we will be able to add retries or take a node down after a failed provisioning.

This is a slightly simpler alternative to #99 which does seem to be stuck.