### PR TITLE
Documentation update, removal of duplicate attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Updates Amazon Web Service's Route 53 (DNS) service.
 
+Amazon Route 53 can be used as DNS for any registered domain name. This cookbook provides a single resource `route53_record` that allows you to create or delete records.
+
+
 ## Requirements
 
 ### Platforms
@@ -46,6 +49,32 @@ NOTE: If you do not specify aws credentials, it will attempt to use the AWS IAM 
 ```ruby
 kitchen converge
 ```
+
+## Resources Overview
+
+### route53_record
+
+#### Parameters
+
+* `name` Required. String. - name of the domain or subdomain.
+* `value` String Array - value appropriate to the `type`.. for type 'A' value would be an IP address in IPv4 format for example.
+* `type` Required. String [DNS record type](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html) 
+* `ttl` Integer default: 3600 - time to live, the amount of time in seconds to cache information about the record
+* `weight` Optional. String. - a value that determines the proportion of DNS queries that will use this record for the response. Valid options are between 0-255. NOT CURRENTLY IMPLEMENTED
+* `set_identifier`  Optional . String. - a value that uniquely identifies record in the group of weighted record sets
+* `geo_location`  String. 
+* `geo_location_country`  String
+* `geo_location_continent`  String
+* `geo_location_subdivision` String
+* `set_identifier` String
+* `zone_id`  String
+* `aws_access_key_id` String
+* `aws_secret_access_key` String
+* `aws_region` String default: 'us-east-1'
+* `overwrite` [TrueClass FalseClass] default: true
+* `alias_target` Optional. Hash. - [Associated with Amazon 'alias' type records. The hash contents varies depending on the type of target the alias points to.](http://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html) 
+* `mock`  [TrueClass FalseClass] default: false 
+* `fail_on_error` [TrueClass FalseClass] default: false
 
 ## ChefSpec Matcher
 

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -11,7 +11,6 @@ attribute :geo_location,                kind_of: String
 attribute :geo_location_country,        kind_of: String
 attribute :geo_location_continent,      kind_of: String
 attribute :geo_location_subdivision,    kind_of: String
-attribute :set_identifier,              kind_of: String
 attribute :zone_id,                     kind_of: String
 attribute :aws_access_key_id,           kind_of: String
 attribute :aws_secret_access_key,       kind_of: String


### PR DESCRIPTION
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Description

Updates the readme for alias target. Removes duplicate set_identifier attribute from resource. Documents that weight attribute is currently not doing anything.

### Issues Resolved

Issue #64 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
