### PR TITLE
Change deprecations to errors in Test Kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  deprecations_as_errors: true
 
 verifier:
   name: inspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,4 @@
 
 Lint/AmbiguousRegexpLiteral:
   Exclude:
-    - 'test/integration/default/serverspec/default_spec.rb'
     - 'test/integration/default/inspec/default_spec.rb'


### PR DESCRIPTION
Remove rubocop exception for non-existing file.
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
