### PR TITLE
Sts role credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ kitchen converge
 * `zone_id`  String
 * `aws_access_key_id` String
 * `aws_secret_access_key` String
+* `aws_sts_role` String
 * `aws_region` String default: 'us-east-1'
 * `overwrite` [true false] default: true
 * `alias_target` Optional. Hash. - [Associated with Amazon 'alias' type records. The hash contents varies depending on the type of target the alias points to.](http://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html) 

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -12,6 +12,20 @@ rescue LoadError
   require 'aws-sdk'
 end
 
+def load_securerandom_gem
+  require 'securerandom'
+  Chef::Log.debug('Node has securerandom gem installed. No need to install gem.')
+rescue LoadError
+  Chef::Log.debug('Did not find securerandom installed. Installing now')
+
+  chef_gem 'securerandom' do
+    compile_time true
+    action :install
+  end
+
+  require 'securerandom'
+end
+
 def name
   @name ||= begin
     return new_resource.name + '.' if new_resource.name !~ /\.$/
@@ -84,16 +98,34 @@ def route53
     if mock?
       @route53 = Aws::Route53::Client.new(stub_responses: true)
     elsif new_resource.aws_access_key_id && new_resource.aws_secret_access_key
-      credentials = Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)
+      if new_resource.aws_sts_role
+        credentials = Aws::AssumeRoleCredentials.new(
+          Aws::STS::Client.new(region:new_resource.aws_region, credentials: Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)), 
+          new_resource.aws_sts_role, 
+          SecureRandom.hex(8))
+      else
+        credentials = Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)
+      end
       @route53 = Aws::Route53::Client.new(
         credentials: credentials,
         region: new_resource.aws_region
       )
     else
       Chef::Log.info 'No AWS credentials supplied, going to attempt to use automatic credentials from IAM or ENV'
-      @route53 = Aws::Route53::Client.new(
-        region: new_resource.aws_region
-      )
+      if new_resource.aws_sts_role
+        credentials = Aws::AssumeRoleCredentials.new(
+          client: Aws::STS::Client.new(region:new_resource.aws_region), 
+          role_arn: new_resource.aws_sts_role, 
+          role_session_name: SecureRandom.hex(8))
+        @route53 = Aws::Route53::Client.new(
+          credentials: credentials,
+          region: new_resource.aws_region
+        )
+      else
+        @route53 = Aws::Route53::Client.new(
+          region: new_resource.aws_region
+        )
+      end
     end
   end
 end
@@ -172,6 +204,7 @@ use_inline_resources
 
 action :create do
   load_aws_gem
+  load_securerandom_gem
 
   if current_resource_record_set == resource_record_set
     Chef::Log.info "Record has not changed, skipping: #{name}[#{type}]"
@@ -186,6 +219,7 @@ end
 
 action :delete do
   load_aws_gem
+  load_securerandom_gem
 
   if mock?
     # Make some fake data so that we can successfully delete when testing.

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -98,14 +98,14 @@ def route53
     if mock?
       @route53 = Aws::Route53::Client.new(stub_responses: true)
     elsif new_resource.aws_access_key_id && new_resource.aws_secret_access_key
-      if new_resource.aws_sts_role
-        credentials = Aws::AssumeRoleCredentials.new(
-          Aws::STS::Client.new(region:new_resource.aws_region, credentials: Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)), 
-          new_resource.aws_sts_role, 
-          SecureRandom.hex(8))
-      else
-        credentials = Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)
-      end
+      credentials = if new_resource.aws_sts_role
+                      Aws::AssumeRoleCredentials.new(
+                        Aws::STS::Client.new(region: new_resource.aws_region, credentials: Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)),
+                        new_resource.aws_sts_role,
+                        SecureRandom.hex(8))
+                    else
+                      Aws::Credentials.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key)
+                    end
       @route53 = Aws::Route53::Client.new(
         credentials: credentials,
         region: new_resource.aws_region
@@ -114,8 +114,8 @@ def route53
       Chef::Log.info 'No AWS credentials supplied, going to attempt to use automatic credentials from IAM or ENV'
       if new_resource.aws_sts_role
         credentials = Aws::AssumeRoleCredentials.new(
-          client: Aws::STS::Client.new(region:new_resource.aws_region), 
-          role_arn: new_resource.aws_sts_role, 
+          client: Aws::STS::Client.new(region: new_resource.aws_region),
+          role_arn: new_resource.aws_sts_role,
           role_session_name: SecureRandom.hex(8))
         @route53 = Aws::Route53::Client.new(
           credentials: credentials,

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -15,6 +15,7 @@ attribute :zone_id,                     kind_of: String
 attribute :aws_access_key_id,           kind_of: String
 attribute :aws_secret_access_key,       kind_of: String
 attribute :aws_region,                  kind_of: String, default: 'us-east-1'
+attribute :aws_sts_role,                kind_of: String
 attribute :overwrite,                   kind_of: [TrueClass, FalseClass], default: true
 attribute :alias_target,                kind_of: Hash
 attribute :mock,                        kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
### Description

Allow for cross-account access to hosted zones by specifying a role to use for STS.  May be other uses for using a role, but cross-account access what I was needing.

Wasn't sure how to go about adding integration tests to create roles involving >1 AWS account, but this is working in our environments whether using STS or not.

Based the credential switching on the aws cookbook example in its [readme](https://github.com/chef-cookbooks/aws#assuming-roles-via-sts-and-using-mfa)

### Issues Resolved

n/a

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
