### PR TITLE
respond_to?(:) for < 12.6 compat

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,6 @@ version          '1.2.1'
   supports os
 end
 
-source_url       'https://github.com/chef-cookbooks/route53'
-issues_url       'https://github.com/chef-cookbooks/route53/issues'
-chef_version '>= 12.1'
+source_url       'https://github.com/chef-cookbooks/route53' if respond_to?(:source_url)
+issues_url       'https://github.com/chef-cookbooks/route53/issues' if respond_to?(:issues_url)
+chef_version '>= 12.1' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,6 @@ version          '1.2.1'
   supports os
 end
 
-source_url       'https://github.com/chef-cookbooks/route53' if respond_to?(:source_url)
-issues_url       'https://github.com/chef-cookbooks/route53/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/chef-cookbooks/route53'
+issues_url       'https://github.com/chef-cookbooks/route53/issues'
 chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Update metadata.rb so that cookbook works on Chef 12.2. Specifically on AWS OpsWorks Windows stacks fail with the following error before the change:

ERROR: Could not read C:/chef/cookbooks/route53 into a Chef object: undefined method `chef_version' for #<Chef::Cookbook::Metadata:0x2a8b7b8>
